### PR TITLE
ci: migrate flatpak/flatpak-github-actions to flatpak-infra/flatpak-github-actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     name: Flatpak
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-nightly
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-47
       options: --privileged
     strategy:
       matrix:
@@ -41,22 +41,29 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
         with:
           submodules: recursive
 
-      - name: Install dependencies
+      # Docker is required by the docker/setup-qemu-action which enables emulation
+      - name: Install docker
+        if: ${{ matrix.arch != 'x86_64' }}
         run: |
-          dnf -y install docker
+          # Use the static binaries because it's unable to use a package manager
+          curl https://download.docker.com/linux/static/stable/x86_64/docker-27.3.1.tgz --output ./docker.tgz
+          tar xzvf docker.tgz
+          mv docker/* /usr/bin
+
+      - name: Install flatpak deps
+        run: flatpak install -y --noninteractive gnome-nightly org.gnome.Platform//master org.gnome.Sdk//master
 
       - name: Set up QEMU
+        if: ${{ matrix.arch != 'x86_64' }}
         id: qemu
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
 
-      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.3
-
+      - uses: flathub-infra/flatpak-github-actions/flatpak-builder@master
         with:
           repository-name: gnome-nightly
           bundle: gradience-devel.flatpak


### PR DESCRIPTION
Fixes deprecation warning upload-artifact of previous flatpak-github-actions.
