### PR TITLE
chore(deps): update bluprint compiler to v0.18.0

### DIFF
--- a/build-aux/flatpak/com.github.hydroxycarbamide.Gradience.Devel.json
+++ b/build-aux/flatpak/com.github.hydroxycarbamide.Gradience.Devel.json
@@ -64,7 +64,7 @@
             "sources" : [
                 {
                     "type" : "git",
-                    "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
+                    "url": "https://github.com/GNOME/blueprint-compiler",
                     "branch" : "main"
                 }
             ]

--- a/build-aux/flatpak/com.github.hydroxycarbamide.Gradience.json
+++ b/build-aux/flatpak/com.github.hydroxycarbamide.Gradience.json
@@ -65,7 +65,7 @@
                 {
                     "type" : "git",
                     "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag" : "v0.16.0"
+                    "tag" : "v0.18.0"
                 }
             ]
         },

--- a/build-aux/flatpak/com.github.hydroxycarbamide.Gradience.json
+++ b/build-aux/flatpak/com.github.hydroxycarbamide.Gradience.json
@@ -64,7 +64,7 @@
             "sources" : [
                 {
                     "type" : "git",
-                    "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
+                    "url": "https://github.com/GNOME/blueprint-compiler",
                     "tag" : "v0.18.0"
                 }
             ]


### PR DESCRIPTION
Update blueprint compiler to v0.18.0
And use the github mirror of blueprint-compiler in order to avoid anubis and stop bothering gnome
It should fix the ci.
